### PR TITLE
make commands locale independent

### DIFF
--- a/RpcEptMapper/README.md
+++ b/RpcEptMapper/README.md
@@ -30,10 +30,6 @@ This script is a fix for RpcEptMapper and Dnscache service permission issue, all
 patch.bat creates the Performance subkey, which can be used for elevation of privilege, and then revokes User access to it.
 This way a non-administrator user cannot create the keys to load a malicious DLL.
 
-# Errors
-
-Error 1337 - if you have non-English language Windows, you need to change "Users" to the name of your local Users group in Windows.
-
 # Disclaimers
 
 SubInAcl.exe is an official Microsoft tool.  This patch is not an official Microsoft tool.

--- a/RpcEptMapper/patch.bat
+++ b/RpcEptMapper/patch.bat
@@ -7,7 +7,7 @@
 @rem -- call from Computer login script in GPO (or psexec \\*)
 
 reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RpcEptMapper\Performance
-subinacl.exe /subkeyreg HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RpcEptMapper\Performance /revoke=Users
+subinacl.exe /subkeyreg HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RpcEptMapper\Performance /revoke=S-1-5-32-545
 
 reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Dnscache\Performance
-subinacl.exe /subkeyreg HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Dnscache\Performance /revoke=Users
+subinacl.exe /subkeyreg HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Dnscache\Performance /revoke=S-1-5-32-545


### PR DESCRIPTION
By using a SID instead of a human-readable name, no changes are required to make the patch run on non-English Windows versions.